### PR TITLE
refactor-global-query-signleton-abstraction

### DIFF
--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -30,16 +30,12 @@ export class GlobalQuery {
         return GlobalQuery.getInstance().new_query();
     }
 
-    static get(): string {
-        return GlobalQuery.getInstance().new_get();
-    }
-
     static set(value: string) {
         GlobalQuery.getInstance().new_set(value);
     }
 
     static isEmpty(): boolean {
-        return GlobalQuery.get().trim() == GlobalQuery.empty;
+        return GlobalQuery.getInstance().new_get().trim() == GlobalQuery.empty;
     }
 
     static explainQuery(): string {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -14,19 +14,19 @@ export class GlobalQuery {
         return GlobalQuery.instance;
     }
 
-    public new_set(value: string) {
+    public set(value: string) {
         this._value = value;
     }
 
-    public new_get() {
+    public get() {
         return this._value;
     }
 
-    public new_query(): Query {
+    public query(): Query {
         return new Query({ source: this._value });
     }
 
-    public new_isEmpty() {
+    public isEmpty() {
         return this._value === GlobalQuery.empty;
     }
 }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -2,7 +2,17 @@ import { Query } from './../Query/Query';
 import { getSettings, updateSettings } from './Settings';
 
 export class GlobalQuery {
+    private static instance: GlobalQuery;
+
     static empty = '';
+
+    public static getInstance(): GlobalQuery {
+        if (!GlobalQuery.instance) {
+            GlobalQuery.instance = new GlobalQuery();
+        }
+
+        return GlobalQuery.instance;
+    }
 
     static query(): Query {
         return new Query({ source: getSettings().globalQuery });

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,5 +1,4 @@
-import { Query } from './../Query/Query';
-import { getSettings, updateSettings } from './Settings';
+import { Query } from '../Query/Query';
 
 export class GlobalQuery {
     private static instance: GlobalQuery;

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -22,8 +22,12 @@ export class GlobalQuery {
         return this._value;
     }
 
+    public new_query(): Query {
+        return new Query({ source: this._value });
+    }
+
     static query(): Query {
-        return new Query({ source: GlobalQuery.getInstance().new_get() });
+        return GlobalQuery.getInstance().new_query();
     }
 
     static get(): string {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -3,7 +3,7 @@ import { Query } from '../Query/Query';
 export class GlobalQuery {
     private static instance: GlobalQuery;
 
-    static empty = '';
+    private static readonly empty = '';
     private _value = GlobalQuery.empty;
 
     public static getInstance(): GlobalQuery {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -5,6 +5,7 @@ export class GlobalQuery {
     private static instance: GlobalQuery;
 
     static empty = '';
+    private _value = GlobalQuery.empty;
 
     public static getInstance(): GlobalQuery {
         if (!GlobalQuery.instance) {
@@ -12,6 +13,10 @@ export class GlobalQuery {
         }
 
         return GlobalQuery.instance;
+    }
+
+    public new_set(value: string) {
+        this._value = value;
     }
 
     static query(): Query {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -26,8 +26,12 @@ export class GlobalQuery {
         return new Query({ source: this._value });
     }
 
+    public new_isEmpty() {
+        return this._value === GlobalQuery.empty;
+    }
+
     static isEmpty(): boolean {
-        return GlobalQuery.getInstance().new_get().trim() == GlobalQuery.empty;
+        return GlobalQuery.getInstance().new_isEmpty();
     }
 
     static explainQuery(): string {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -33,8 +33,4 @@ export class GlobalQuery {
     static explainQuery(): string {
         return GlobalQuery.getInstance().new_query().explainQuery();
     }
-
-    static reset() {
-        GlobalQuery.getInstance().new_set(GlobalQuery.empty);
-    }
 }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -30,10 +30,6 @@ export class GlobalQuery {
         return this._value === GlobalQuery.empty;
     }
 
-    static isEmpty(): boolean {
-        return GlobalQuery.getInstance().new_isEmpty();
-    }
-
     static explainQuery(): string {
         return GlobalQuery.getInstance().new_query().explainQuery();
     }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -26,16 +26,12 @@ export class GlobalQuery {
         return new Query({ source: this._value });
     }
 
-    static query(): Query {
-        return GlobalQuery.getInstance().new_query();
-    }
-
     static isEmpty(): boolean {
         return GlobalQuery.getInstance().new_get().trim() == GlobalQuery.empty;
     }
 
     static explainQuery(): string {
-        return GlobalQuery.query().explainQuery();
+        return GlobalQuery.getInstance().new_query().explainQuery();
     }
 
     static reset() {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -19,6 +19,10 @@ export class GlobalQuery {
         this._value = value;
     }
 
+    public new_get() {
+        return this._value;
+    }
+
     static query(): Query {
         return new Query({ source: getSettings().globalQuery });
     }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -28,7 +28,7 @@ export class GlobalQuery {
     }
 
     static set(value: string) {
-        updateSettings({ globalQuery: value });
+        GlobalQuery.getInstance().new_set(value);
     }
 
     static isEmpty(): boolean {
@@ -40,6 +40,6 @@ export class GlobalQuery {
     }
 
     static reset() {
-        updateSettings({ globalQuery: GlobalQuery.empty });
+        GlobalQuery.getInstance().new_set(GlobalQuery.empty);
     }
 }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -29,8 +29,4 @@ export class GlobalQuery {
     public new_isEmpty() {
         return this._value === GlobalQuery.empty;
     }
-
-    static explainQuery(): string {
-        return GlobalQuery.getInstance().new_query().explainQuery();
-    }
 }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -30,10 +30,6 @@ export class GlobalQuery {
         return GlobalQuery.getInstance().new_query();
     }
 
-    static set(value: string) {
-        GlobalQuery.getInstance().new_set(value);
-    }
-
     static isEmpty(): boolean {
         return GlobalQuery.getInstance().new_get().trim() == GlobalQuery.empty;
     }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -24,11 +24,11 @@ export class GlobalQuery {
     }
 
     static query(): Query {
-        return new Query({ source: getSettings().globalQuery });
+        return new Query({ source: GlobalQuery.getInstance().new_get() });
     }
 
     static get(): string {
-        return getSettings().globalQuery;
+        return GlobalQuery.getInstance().new_get();
     }
 
     static set(value: string) {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -12,6 +12,10 @@ export class GlobalQuery {
         return source.trim() == '';
     }
 
+    static explain() {
+        return GlobalQuery.get().explainQuery();
+    }
+
     /**
      * Retrieves the source of the global {@link Query}
      */

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,1 +1,10 @@
-export class GlobalQuery {}
+import { getSettings } from './Settings';
+
+export class GlobalQuery {
+    /**
+     * Retrieves the source of the global {@link Query}
+     */
+    static source(): { source: string } {
+        return { source: getSettings().globalQuery };
+    }
+}

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,10 +1,14 @@
 import { Query } from './../Query/Query';
-import { getSettings } from './Settings';
+import { getSettings, updateSettings } from './Settings';
 
 export class GlobalQuery {
     static get(): Query {
         const globalQuerySource = GlobalQuery.source();
         return new Query(globalQuerySource);
+    }
+
+    static set(value: string) {
+        updateSettings({ globalQuery: value });
     }
 
     static isEmpty() {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -8,8 +8,7 @@ export class GlobalQuery {
     }
 
     static isEmpty() {
-        const source = GlobalQuery.source().source;
-        return source.trim() == '';
+        return GlobalQuery.string().trim() == '';
     }
 
     static explain() {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,0 +1,1 @@
+export class GlobalQuery {}

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -7,6 +7,11 @@ export class GlobalQuery {
         return new Query(globalQuerySource);
     }
 
+    static isEmpty() {
+        const source = GlobalQuery.source().source;
+        return source.trim() == '';
+    }
+
     /**
      * Retrieves the source of the global {@link Query}
      */

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -5,15 +5,7 @@ export class GlobalQuery {
     static empty = '';
 
     static get(): Query {
-        const globalQuerySource = GlobalQuery.source();
-        return new Query(globalQuerySource);
-    }
-
-    /**
-     * Retrieves the source of the global {@link Query}
-     */
-    static source(): { source: string } {
-        return { source: getSettings().globalQuery };
+        return new Query({ source: getSettings().globalQuery });
     }
 
     static string() {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -23,6 +23,10 @@ export class GlobalQuery {
         return getSettings().globalQuery;
     }
 
+    static reset() {
+        updateSettings({ globalQuery: '' });
+    }
+
     /**
      * Retrieves the source of the global {@link Query}
      */

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -16,6 +16,10 @@ export class GlobalQuery {
         return GlobalQuery.get().explainQuery();
     }
 
+    static string() {
+        return getSettings().globalQuery;
+    }
+
     /**
      * Retrieves the source of the global {@link Query}
      */

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -8,7 +8,7 @@ export class GlobalQuery {
         return new Query({ source: getSettings().globalQuery });
     }
 
-    static string() {
+    static string(): string {
         return getSettings().globalQuery;
     }
 
@@ -16,11 +16,11 @@ export class GlobalQuery {
         updateSettings({ globalQuery: value });
     }
 
-    static isEmpty() {
+    static isEmpty(): boolean {
         return GlobalQuery.string().trim() == GlobalQuery.empty;
     }
 
-    static explain() {
+    static explain(): string {
         return GlobalQuery.get().explainQuery();
     }
 

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -20,7 +20,7 @@ export class GlobalQuery {
         return GlobalQuery.get().trim() == GlobalQuery.empty;
     }
 
-    static explain(): string {
+    static explainQuery(): string {
         return GlobalQuery.query().explainQuery();
     }
 

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -1,6 +1,12 @@
+import { Query } from './../Query/Query';
 import { getSettings } from './Settings';
 
 export class GlobalQuery {
+    static get(): Query {
+        const globalQuerySource = GlobalQuery.source();
+        return new Query(globalQuerySource);
+    }
+
     /**
      * Retrieves the source of the global {@link Query}
      */

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -4,11 +4,11 @@ import { getSettings, updateSettings } from './Settings';
 export class GlobalQuery {
     static empty = '';
 
-    static get(): Query {
+    static query(): Query {
         return new Query({ source: getSettings().globalQuery });
     }
 
-    static string(): string {
+    static get(): string {
         return getSettings().globalQuery;
     }
 
@@ -17,11 +17,11 @@ export class GlobalQuery {
     }
 
     static isEmpty(): boolean {
-        return GlobalQuery.string().trim() == GlobalQuery.empty;
+        return GlobalQuery.get().trim() == GlobalQuery.empty;
     }
 
     static explain(): string {
-        return GlobalQuery.get().explainQuery();
+        return GlobalQuery.query().explainQuery();
     }
 
     static reset() {

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -9,6 +9,17 @@ export class GlobalQuery {
         return new Query(globalQuerySource);
     }
 
+    /**
+     * Retrieves the source of the global {@link Query}
+     */
+    static source(): { source: string } {
+        return { source: getSettings().globalQuery };
+    }
+
+    static string() {
+        return getSettings().globalQuery;
+    }
+
     static set(value: string) {
         updateSettings({ globalQuery: value });
     }
@@ -21,18 +32,7 @@ export class GlobalQuery {
         return GlobalQuery.get().explainQuery();
     }
 
-    static string() {
-        return getSettings().globalQuery;
-    }
-
     static reset() {
         updateSettings({ globalQuery: GlobalQuery.empty });
-    }
-
-    /**
-     * Retrieves the source of the global {@link Query}
-     */
-    static source(): { source: string } {
-        return { source: getSettings().globalQuery };
     }
 }

--- a/src/Config/GlobalQuery.ts
+++ b/src/Config/GlobalQuery.ts
@@ -2,6 +2,8 @@ import { Query } from './../Query/Query';
 import { getSettings, updateSettings } from './Settings';
 
 export class GlobalQuery {
+    static empty = '';
+
     static get(): Query {
         const globalQuerySource = GlobalQuery.source();
         return new Query(globalQuerySource);
@@ -12,7 +14,7 @@ export class GlobalQuery {
     }
 
     static isEmpty() {
-        return GlobalQuery.string().trim() == '';
+        return GlobalQuery.string().trim() == GlobalQuery.empty;
     }
 
     static explain() {
@@ -24,7 +26,7 @@ export class GlobalQuery {
     }
 
     static reset() {
-        updateSettings({ globalQuery: '' });
+        updateSettings({ globalQuery: GlobalQuery.empty });
     }
 
     /**

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -11,7 +11,6 @@ import { StatusSettings } from './StatusSettings';
 import { Feature } from './Feature';
 import type { FeatureFlag } from './Feature';
 import { GlobalFilter } from './GlobalFilter';
-import { GlobalQuery } from './GlobalQuery';
 
 interface SettingsMap {
     [key: string]: string | boolean;
@@ -51,7 +50,6 @@ export const TASK_FORMATS = {
 export type TASK_FORMATS = typeof TASK_FORMATS; // For convenience to make some typing easier
 
 export interface Settings {
-    globalQuery: string;
     globalFilter: string;
     removeGlobalFilter: boolean;
     taskFormat: keyof TASK_FORMATS;
@@ -81,7 +79,6 @@ export interface Settings {
 }
 
 const defaultSettings: Settings = {
-    globalQuery: GlobalQuery.empty,
     globalFilter: GlobalFilter.empty,
     removeGlobalFilter: false,
     taskFormat: 'tasksPluginEmoji',

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -11,6 +11,7 @@ import { StatusSettings } from './StatusSettings';
 import { Feature } from './Feature';
 import type { FeatureFlag } from './Feature';
 import { GlobalFilter } from './GlobalFilter';
+import { GlobalQuery } from './GlobalQuery';
 
 interface SettingsMap {
     [key: string]: string | boolean;
@@ -80,7 +81,7 @@ export interface Settings {
 }
 
 const defaultSettings: Settings = {
-    globalQuery: '',
+    globalQuery: GlobalQuery.empty,
     globalFilter: GlobalFilter.empty,
     removeGlobalFilter: false,
     taskFormat: 'tasksPluginEmoji',

--- a/src/Config/Settings.ts
+++ b/src/Config/Settings.ts
@@ -202,12 +202,3 @@ export const toggleFeature = (internalName: string, enabled: boolean): FeatureFl
 export function getUserSelectedTaskFormat(): TaskFormat {
     return TASK_FORMATS[getSettings().taskFormat];
 }
-
-/**
- * Retrieves the source of the global {@link Query}
- *
- * @exports
- */
-export function getGlobalQuerySource(): { source: string } {
-    return { source: getSettings().globalQuery };
-}

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -141,7 +141,7 @@ export class SettingsTab extends PluginSettingTab {
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
                         .setValue(GlobalQuery.getInstance().new_get())
                         .onChange(async (value) => {
-                            GlobalQuery.set(value);
+                            GlobalQuery.getInstance().new_set(value);
                             await this.plugin.saveSettings();
                         });
                 }),

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -139,7 +139,7 @@ export class SettingsTab extends PluginSettingTab {
                 .addTextArea((text) => {
                     text.inputEl.rows = 4;
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
-                        .setValue(GlobalQuery.get())
+                        .setValue(GlobalQuery.getInstance().new_get())
                         .onChange(async (value) => {
                             GlobalQuery.set(value);
                             await this.plugin.saveSettings();

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -139,9 +139,9 @@ export class SettingsTab extends PluginSettingTab {
                 .addTextArea((text) => {
                     text.inputEl.rows = 4;
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
-                        .setValue(GlobalQuery.getInstance().new_get())
+                        .setValue(GlobalQuery.getInstance().get())
                         .onChange(async (value) => {
-                            GlobalQuery.getInstance().new_set(value);
+                            GlobalQuery.getInstance().set(value);
                             await this.plugin.saveSettings();
                         });
                 }),

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -141,8 +141,7 @@ export class SettingsTab extends PluginSettingTab {
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
                         .setValue(GlobalQuery.string())
                         .onChange(async (value) => {
-                            updateSettings({ globalQuery: value });
-
+                            GlobalQuery.set(value);
                             await this.plugin.saveSettings();
                         });
                 }),

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -12,6 +12,7 @@ import { StatusSettings } from './StatusSettings';
 import settingsJson from './settingsConfiguration.json';
 
 import { CustomStatusModal } from './CustomStatusModal';
+import { GlobalQuery } from './GlobalQuery';
 
 export class SettingsTab extends PluginSettingTab {
     // If the UI needs a more complex setting you can create a
@@ -136,11 +137,9 @@ export class SettingsTab extends PluginSettingTab {
                     ),
                 )
                 .addTextArea((text) => {
-                    const settings = getSettings();
-
                     text.inputEl.rows = 4;
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
-                        .setValue(settings.globalQuery)
+                        .setValue(GlobalQuery.string())
                         .onChange(async (value) => {
                             updateSettings({ globalQuery: value });
 

--- a/src/Config/SettingsTab.ts
+++ b/src/Config/SettingsTab.ts
@@ -139,7 +139,7 @@ export class SettingsTab extends PluginSettingTab {
                 .addTextArea((text) => {
                     text.inputEl.rows = 4;
                     text.setPlaceholder('# For example...\npath does not include _templates/\nlimit 300\nshow urgency')
-                        .setValue(GlobalQuery.string())
+                        .setValue(GlobalQuery.get())
                         .onChange(async (value) => {
                             GlobalQuery.set(value);
                             await this.plugin.saveSettings();

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -32,8 +32,8 @@ export function explainResults(source: string): string {
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
         const globalQuery = GlobalQuery.getInstance();
-        if (!globalQuery.new_isEmpty()) {
-            result += `Explanation of the global query:\n\n${globalQuery.new_query().explainQuery()}\n`;
+        if (!globalQuery.isEmpty()) {
+            result += `Explanation of the global query:\n\n${globalQuery.query().explainQuery()}\n`;
         }
     }
 
@@ -57,6 +57,6 @@ export function getQueryForQueryRenderer(source: string): Query {
         return tasksBlockQuery;
     }
 
-    const globalQuery = GlobalQuery.getInstance().new_query();
+    const globalQuery = GlobalQuery.getInstance().query();
     return globalQuery.append(tasksBlockQuery);
 }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -56,6 +56,6 @@ export function getQueryForQueryRenderer(source: string): Query {
         return tasksBlockQuery;
     }
 
-    const globalQuery = GlobalQuery.query();
+    const globalQuery = GlobalQuery.getInstance().new_query();
     return globalQuery.append(tasksBlockQuery);
 }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -31,8 +31,9 @@ export function explainResults(source: string): string {
     const tasksBlockQuery = new Query({ source });
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        if (!GlobalQuery.getInstance().new_isEmpty()) {
-            result += `Explanation of the global query:\n\n${GlobalQuery.getInstance().new_query().explainQuery()}\n`;
+        const globalQuery = GlobalQuery.getInstance();
+        if (!globalQuery.new_isEmpty()) {
+            result += `Explanation of the global query:\n\n${globalQuery.new_query().explainQuery()}\n`;
         }
     }
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -31,7 +31,7 @@ export function explainResults(source: string): string {
     const tasksBlockQuery = new Query({ source });
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        if (!GlobalQuery.isEmpty()) {
+        if (!GlobalQuery.getInstance().new_isEmpty()) {
             result += `Explanation of the global query:\n\n${GlobalQuery.explainQuery()}\n`;
         }
     }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -32,7 +32,7 @@ export function explainResults(source: string): string {
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
         if (!GlobalQuery.getInstance().new_isEmpty()) {
-            result += `Explanation of the global query:\n\n${GlobalQuery.explainQuery()}\n`;
+            result += `Explanation of the global query:\n\n${GlobalQuery.getInstance().new_query().explainQuery()}\n`;
         }
     }
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -33,7 +33,7 @@ export function explainResults(source: string): string {
     if (!tasksBlockQuery.ignoreGlobalQuery) {
         const globalQuery = GlobalQuery.get();
 
-        if (globalQuery.source.trim() !== '') {
+        if (!GlobalQuery.isEmpty()) {
             result += `Explanation of the global query:\n\n${globalQuery.explainQuery()}\n`;
         }
     }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -1,4 +1,3 @@
-import type { IQuery } from '../IQuery';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { Query } from '../Query/Query';
 import { GlobalQuery } from '../Config/GlobalQuery';
@@ -32,7 +31,7 @@ export function explainResults(source: string): string {
     const tasksBlockQuery = new Query({ source });
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        const globalQuery: IQuery = new Query(GlobalQuery.source());
+        const globalQuery = GlobalQuery.get();
 
         if (globalQuery.source.trim() !== '') {
             result += `Explanation of the global query:\n\n${globalQuery.explainQuery()}\n`;
@@ -53,7 +52,7 @@ export function explainResults(source: string): string {
  * @returns {Query} The query to execute
  */
 export function getQueryForQueryRenderer(source: string): Query {
-    const globalQuery = new Query(GlobalQuery.source());
+    const globalQuery = GlobalQuery.get();
     const tasksBlockQuery = new Query({ source });
 
     if (tasksBlockQuery.ignoreGlobalQuery) {

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -32,7 +32,7 @@ export function explainResults(source: string): string {
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
         if (!GlobalQuery.isEmpty()) {
-            result += `Explanation of the global query:\n\n${GlobalQuery.explain()}\n`;
+            result += `Explanation of the global query:\n\n${GlobalQuery.explainQuery()}\n`;
         }
     }
 

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -56,6 +56,6 @@ export function getQueryForQueryRenderer(source: string): Query {
         return tasksBlockQuery;
     }
 
-    const globalQuery = GlobalQuery.get();
+    const globalQuery = GlobalQuery.query();
     return globalQuery.append(tasksBlockQuery);
 }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -1,7 +1,7 @@
 import type { IQuery } from '../IQuery';
-import { getGlobalQuerySource } from '../Config/Settings';
 import { GlobalFilter } from '../Config/GlobalFilter';
 import { Query } from '../Query/Query';
+import { GlobalQuery } from '../Config/GlobalQuery';
 
 /**
  * @summary
@@ -32,7 +32,7 @@ export function explainResults(source: string): string {
     const tasksBlockQuery = new Query({ source });
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        const globalQuery: IQuery = new Query(getGlobalQuerySource());
+        const globalQuery: IQuery = new Query(GlobalQuery.source());
 
         if (globalQuery.source.trim() !== '') {
             result += `Explanation of the global query:\n\n${globalQuery.explainQuery()}\n`;
@@ -53,7 +53,7 @@ export function explainResults(source: string): string {
  * @returns {Query} The query to execute
  */
 export function getQueryForQueryRenderer(source: string): Query {
-    const globalQuery = new Query(getGlobalQuerySource());
+    const globalQuery = new Query(GlobalQuery.source());
     const tasksBlockQuery = new Query({ source });
 
     if (tasksBlockQuery.ignoreGlobalQuery) {

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -52,12 +52,12 @@ export function explainResults(source: string): string {
  * @returns {Query} The query to execute
  */
 export function getQueryForQueryRenderer(source: string): Query {
-    const globalQuery = GlobalQuery.get();
     const tasksBlockQuery = new Query({ source });
 
     if (tasksBlockQuery.ignoreGlobalQuery) {
         return tasksBlockQuery;
     }
 
+    const globalQuery = GlobalQuery.get();
     return globalQuery.append(tasksBlockQuery);
 }

--- a/src/lib/QueryRendererHelper.ts
+++ b/src/lib/QueryRendererHelper.ts
@@ -31,10 +31,8 @@ export function explainResults(source: string): string {
     const tasksBlockQuery = new Query({ source });
 
     if (!tasksBlockQuery.ignoreGlobalQuery) {
-        const globalQuery = GlobalQuery.get();
-
         if (!GlobalQuery.isEmpty()) {
-            result += `Explanation of the global query:\n\n${globalQuery.explainQuery()}\n`;
+            result += `Explanation of the global query:\n\n${GlobalQuery.explain()}\n`;
         }
     }
 

--- a/tests/Query/Explain/DocsSamplesForExplain.test.ts
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import moment from 'moment';
+import { GlobalQuery } from '../../../src/Config/GlobalQuery';
 import { verifyQuery, verifyTaskBlockExplanation } from '../../TestingTools/ApprovalTestHelpers';
-import { resetSettings, updateSettings } from '../../../src/Config/Settings';
+import { resetSettings } from '../../../src/Config/Settings';
 window.moment = moment;
 
 function checkExplainPresentAndVerify(blockQuery: string) {
@@ -79,7 +80,7 @@ heading includes tasks`;
 
     it('explains task block with global query active', () => {
         // Arrange
-        updateSettings({ globalQuery });
+        GlobalQuery.getInstance().new_set(globalQuery);
 
         const blockQuery = `
 not done

--- a/tests/Query/Explain/DocsSamplesForExplain.test.ts
+++ b/tests/Query/Explain/DocsSamplesForExplain.test.ts
@@ -80,7 +80,7 @@ heading includes tasks`;
 
     it('explains task block with global query active', () => {
         // Arrange
-        GlobalQuery.getInstance().new_set(globalQuery);
+        GlobalQuery.getInstance().set(globalQuery);
 
         const blockQuery = `
 not done

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -40,7 +40,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query active', () => {
-        GlobalQuery.getInstance().new_set('description includes hello');
+        GlobalQuery.getInstance().set('description includes hello');
 
         const source = '';
         const query = new Query({ source });
@@ -57,7 +57,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query and global filter active', () => {
-        GlobalQuery.getInstance().new_set('description includes hello');
+        GlobalQuery.getInstance().set('description includes hello');
         GlobalFilter.set('#task');
 
         const source = '';
@@ -77,7 +77,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query set but ignored without the global query', () => {
-        GlobalQuery.getInstance().new_set('description includes hello');
+        GlobalQuery.getInstance().set('description includes hello');
 
         const source = 'ignore global query';
         const query = new Query({ source });
@@ -99,12 +99,12 @@ describe('query used for QueryRenderer', () => {
     it('should be the result of combining the global query and the actual query', () => {
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        GlobalQuery.getInstance().new_set(globalQuerySource);
+        GlobalQuery.getInstance().set(globalQuerySource);
         expect(getQueryForQueryRenderer(querySource).source).toEqual(`${globalQuerySource}\n${querySource}`);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
-        GlobalQuery.getInstance().new_set('path includes from_global_query');
+        GlobalQuery.getInstance().set('path includes from_global_query');
         expect(getQueryForQueryRenderer('description includes from_block_query\nignore global query').source).toEqual(
             'description includes from_block_query\nignore global query',
         );

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -41,7 +41,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query active', () => {
-        GlobalQuery.set('description includes hello');
+        GlobalQuery.getInstance().new_set('description includes hello');
 
         const source = '';
         const query = new Query({ source });
@@ -58,7 +58,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query and global filter active', () => {
-        GlobalQuery.set('description includes hello');
+        GlobalQuery.getInstance().new_set('description includes hello');
         GlobalFilter.set('#task');
 
         const source = '';
@@ -78,7 +78,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query set but ignored without the global query', () => {
-        GlobalQuery.set('description includes hello');
+        GlobalQuery.getInstance().new_set('description includes hello');
 
         const source = 'ignore global query';
         const query = new Query({ source });
@@ -104,12 +104,12 @@ describe('query used for QueryRenderer', () => {
     it('should be the result of combining the global query and the actual query', () => {
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        GlobalQuery.set(globalQuerySource);
+        GlobalQuery.getInstance().new_set(globalQuerySource);
         expect(getQueryForQueryRenderer(querySource).source).toEqual(`${globalQuerySource}\n${querySource}`);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
-        GlobalQuery.set('path includes from_global_query');
+        GlobalQuery.getInstance().new_set('path includes from_global_query');
         expect(getQueryForQueryRenderer('description includes from_block_query\nignore global query').source).toEqual(
             'description includes from_block_query\nignore global query',
         );

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -11,7 +11,6 @@ window.moment = moment;
 
 describe('explain', () => {
     afterEach(() => {
-        GlobalQuery.reset();
         GlobalFilter.reset();
     });
 
@@ -97,10 +96,6 @@ No filters supplied. All tasks will match the query.`;
  *       the right query.
  */
 describe('query used for QueryRenderer', () => {
-    afterEach(() => {
-        GlobalQuery.reset();
-    });
-
     it('should be the result of combining the global query and the actual query', () => {
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -3,9 +3,10 @@
  */
 import moment from 'moment';
 import { Query } from '../../src/Query/Query';
-import { resetSettings, updateSettings } from '../../src/Config/Settings';
+import { resetSettings } from '../../src/Config/Settings';
 import { explainResults, getQueryForQueryRenderer } from '../../src/lib/QueryRendererHelper';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
+import { GlobalQuery } from '../../src/Config/GlobalQuery';
 
 window.moment = moment;
 
@@ -41,7 +42,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query active', () => {
-        updateSettings({ globalQuery: 'description includes hello' });
+        GlobalQuery.set('description includes hello');
 
         const source = '';
         const query = new Query({ source });
@@ -58,7 +59,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query and global filter active', () => {
-        updateSettings({ globalQuery: 'description includes hello' });
+        GlobalQuery.set('description includes hello');
         GlobalFilter.set('#task');
 
         const source = '';
@@ -78,7 +79,7 @@ No filters supplied. All tasks will match the query.`;
     });
 
     it('should explain a task with global query set but ignored without the global query', () => {
-        updateSettings({ globalQuery: 'description includes hello' });
+        GlobalQuery.set('description includes hello');
 
         const source = 'ignore global query';
         const query = new Query({ source });
@@ -104,12 +105,12 @@ describe('query used for QueryRenderer', () => {
     it('should be the result of combining the global query and the actual query', () => {
         const querySource = 'description includes world';
         const globalQuerySource = 'description includes hello';
-        updateSettings({ globalQuery: globalQuerySource });
+        GlobalQuery.set(globalQuerySource);
         expect(getQueryForQueryRenderer(querySource).source).toEqual(`${globalQuerySource}\n${querySource}`);
     });
 
     it('should ignore the global query if "ignore global query" is set', () => {
-        updateSettings({ globalQuery: 'path includes from_global_query' });
+        GlobalQuery.set('path includes from_global_query');
         expect(getQueryForQueryRenderer('description includes from_block_query\nignore global query').source).toEqual(
             'description includes from_block_query\nignore global query',
         );

--- a/tests/lib/QueryRendererHelper.test.ts
+++ b/tests/lib/QueryRendererHelper.test.ts
@@ -3,7 +3,6 @@
  */
 import moment from 'moment';
 import { Query } from '../../src/Query/Query';
-import { resetSettings } from '../../src/Config/Settings';
 import { explainResults, getQueryForQueryRenderer } from '../../src/lib/QueryRendererHelper';
 import { GlobalFilter } from '../../src/Config/GlobalFilter';
 import { GlobalQuery } from '../../src/Config/GlobalQuery';
@@ -12,7 +11,7 @@ window.moment = moment;
 
 describe('explain', () => {
     afterEach(() => {
-        resetSettings();
+        GlobalQuery.reset();
         GlobalFilter.reset();
     });
 
@@ -99,7 +98,7 @@ No filters supplied. All tasks will match the query.`;
  */
 describe('query used for QueryRenderer', () => {
     afterEach(() => {
-        resetSettings();
+        GlobalQuery.reset();
     });
 
     it('should be the result of combining the global query and the actual query', () => {


### PR DESCRIPTION
# Description

Move `GlobalQuery` from `Settings` to a singleton abstraction.

This PR is a refactored PR https://github.com/obsidian-tasks-group/obsidian-tasks/pull/2209

## Motivation and Context

We discussed several times that this is needed so I found some time =)

## How has this been tested?

Unit tests.

## Types of changes


Internal changes:

- [x] **Refactor** (prefix: `refactor` - non-breaking change which only improves the design or structure of existing code, and making no changes to its external behaviour)
- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)
- [ ] **Infrastructure** (prefix: `chore` - examples include GitHub Actions, issue templates)

## Checklist

- [x] My code follows the code style of this project and passes `yarn run lint`.
- [x] My change has adequate [Unit Test coverage](https://publish.obsidian.md/tasks-contributing/Testing/About+Testing).

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
